### PR TITLE
adding ignore case for grep

### DIFF
--- a/_posts/2022-07-01-using-ca-trusted-fingerprint.md
+++ b/_posts/2022-07-01-using-ca-trusted-fingerprint.md
@@ -24,7 +24,7 @@ openssl s_client \
 if you have an actual certificate file for the CA you can just load it:
 
 ```
- openssl x509 -in ca_file.pem -sha256 -fingerprint | grep SHA256 | sed 's/://g'
+ openssl x509 -in ca_file.pem -sha256 -fingerprint | grep -i SHA256 | sed 's/://g'
 ```
 
 The response will be something like


### PR DESCRIPTION
to make sure it works better across environments, the original didn't work for me without `-i` because for whatever reason my openssl output had "sha256 Fingerprint=..."

OpenSSL 3.2.1 30 Jan 2024 (Library: OpenSSL 3.2.1 30 Jan 2024)